### PR TITLE
Return `id` and `link` in API success response

### DIFF
--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -100,12 +100,16 @@ class RestAPI {
 		);
 
 		// Store the results.
-		wp_insert_post( $results );
+		$post_id = wp_insert_post( $results, true );
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
 
 		// Create the response object.
 		$response = new \WP_REST_Response(
 			array(
-				'success' => true,
+				'id'    => $post_id,
+				'link'  => get_permalink( $post_id )
 			)
 		);
 

--- a/tests/test-restapi.php
+++ b/tests/test-restapi.php
@@ -37,7 +37,8 @@ class TestRestAPI extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 
-		$this->assertTrue( $data['success'] );
+		$this->assertTrue( isset( $data['id'] ) );
+		$this->assertTrue( isset( $data['link'] ) );
 
 		$parent = get_page_by_path( 'r1234', 'OBJECT', 'result' );
 


### PR DESCRIPTION
'success' is implied by the http response code

Related https://github.com/octalmage/WP-Unit-Test-Runner/issues/27